### PR TITLE
Paho MQTT-SN gateway broadcast address changed

### DIFF
--- a/init_files/etc/paho-mqtt-sn-gateway.conf
+++ b/init_files/etc/paho-mqtt-sn-gateway.conf
@@ -36,9 +36,12 @@ GatewayPortNo=10000
 MulticastIP=225.1.1.1
 MulticastPortNo=1883
 
+# GatewayUDP6Broadcast address is set to all Thread devices address
+# in order to enable Thread Sleepy Devices to receive multicast messages
+# sent from the gateway.
 # UDP6
 GatewayUDP6Port = 47193
-GatewayUDP6Broadcast = ff03::1
+GatewayUDP6Broadcast = ff33:40:fdde:ad00:beef:0:0:1
 GatewayUDP6If = wpan0
 
 # XBee


### PR DESCRIPTION
MQTT-SN Gateway UDP6 broadcast address temporarily changed to enable multicast communication with Thread Sleepy End devices.